### PR TITLE
Added the copyme functionality

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -14,6 +14,9 @@ mkdir_cd() {
 alias www="list_ips && ls_pwd && sudo python3 -m http.server 80"
 alias tun0="ifconfig tun0 | grep 'inet ' | cut -d' ' -f10 | tr -d '\n' | xclip -sel clip"
 
+# Copy functionality to more easily copy text/output from terminal to being able to paste it elsewhere
+alias copyme='xclip -sel clip'
+
 # seclist_path
 get_seclists_dir() {
   local dir


### PR DESCRIPTION
Added a Copy functionality to more easily copy text/output from terminal to being able to paste it elsewhere

i call it `copyme` but you can if wanted, just change it to something else if wanted so

example i use alot is:
`tun0 | copyme` 

then i can simply go to the place i need to paste in my ip without needing to write `tun0` then copy it and THEN paste it. 

Just a small feature i thought would be nice here :) 